### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Blitz.Rpc.Client/Blitz.Rpc.Client.csproj
+++ b/src/Blitz.Rpc.Client/Blitz.Rpc.Client.csproj
@@ -7,7 +7,15 @@
     <LangVersion>7.3</LangVersion>
     <Version>2.0.2</Version>
     <Authors>PEtter Ekrann</Authors>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Blitz.Rpc.Shared" Version="2.0.1" />

--- a/src/Blitz.Rpc.HttpHelper/Blitz.Rpc.Client.Helper.csproj
+++ b/src/Blitz.Rpc.HttpHelper/Blitz.Rpc.Client.Helper.csproj
@@ -10,7 +10,15 @@
     <RepositoryUrl>https://github.com/petterek/Blitz.Rpc</RepositoryUrl>
     <PackageProjectUrl>https://github.com/petterek/Blitz.Rpc</PackageProjectUrl>
     <PackageTags>WebRpc dotnet</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath></OutputPath>

--- a/src/Blitz.Rpc.Server/Blitz.Rpc.HttpServer.csproj
+++ b/src/Blitz.Rpc.Server/Blitz.Rpc.HttpServer.csproj
@@ -10,7 +10,15 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <Version>2.0.5</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Blitz.Rpc.Client" Version="2.0.2" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
